### PR TITLE
SD_HSMCI.h: fix SD_MMC_0_CD_GPIO

### DIFF
--- a/src/SD_HSMCI/SD_HSMCI.h
+++ b/src/SD_HSMCI/SD_HSMCI.h
@@ -81,7 +81,7 @@
 	PIOA, ID_PIOA, PIO_PERIPH_A, PIO_PULLUP }
 #ifdef __MACCHINA_M2
 #define PIN_HSMCI_CD {PIO_PC30, PIOC, ID_PIOC, PIO_INPUT, PIO_PULLUP}
-#define SD_MMC_0_CD_GPIO            64//(PIO_PB27_IDX) //Macchina M2 digital pin 64
+#define SD_MMC_0_CD_GPIO            36//(PIO_PB27_IDX) //Macchina M2 digital pin 36
 #define SD_MMC_0_CD_GPIO_INSTRUMENT DS2//(PIO_PB27_IDX) //Macchina M2 digital pin Red_Led
 #define SD_MMC_0_CD_PIO_ID          ID_PIOA
 #define SD_MMC_0_CD_FLAGS           (PIO_INPUT | PIO_PULLUP)


### PR DESCRIPTION
Fixes #11 by changing the SD card detect pin from SWC_M0 (64) to SD_SW (36) which is connected to the SD slot switch.

As a side effect, this fixes a anomaly I noticed a few days ago which is I would expect that running an example SD sketch with no SD card inserted should produce:
```
MS: Cannot initialize the SD card: MS: Card not found
```

but it in fact produces:
```
MS: Cannot initialize the SD card: MS: Card is unusable, try another one
```